### PR TITLE
allow for setting max offset via config function

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -452,8 +452,8 @@ func (h *Handler) handleFetch(ctx *Context, req *protocol.FetchRequest) *protoco
 				return
 			}
 
-			// If an offset is being request that we don't yet have available, a partition response
-			// with no records should be returned.
+			// If an offset is being requested that we don't yet have available, a partition
+			// response with no records should be returned.
 			startingOffset := fetchTopic.Partitions[0].FetchOffset
 			if startingOffset > maxOffsetAvailable {
 				responseChan <- &protocol.FetchTopicResponse{

--- a/handler.go
+++ b/handler.go
@@ -25,10 +25,9 @@ const (
 // ClusterID we will use when talking to clients.
 var ClusterID = "dekafclusterid"
 
-// RecordsAvailableFn allows behavior controlling the number of available records the server should
-// emulate be provided as configuration when initializing the server. In a typical case, the
-// function could return a larger and larger value based on the passage of time since
-// initialization.
+// RecordsAvailableFn allows for controlling the number of available records the server should
+// emulate. In a typical case, the function could return a larger and larger value based on the
+// passage of time since initialization.
 type RecordsAvailableFn func() int64
 
 // Config defines the handler config


### PR DESCRIPTION
This change allows for a more realistic simulation of data becoming available over time by adding a configuration field for a function that will return a maximum offset that the server should simulate as available. It is based on time: At a given point in time, the configured function should be able to return an integer representing how many records there are available.

For example, a function factory like this could be used to simulate 3 records being added per second, with the "start" time captured in the closure:
```go
func newMaxOffsetFn(start time.Time) dekaf.MaxOffsetFn {
	// Simulates 3 messages being generate per second, via the maximimum available offset increasing
	// by 3 for every second that has passed since the server started.
	return func(at time.Time) int64 {
		delta := at.Sub(start)
		ps := int64(delta / time.Second)
		return ps * 3
	}
}
```

This is a simplistic implementation and requires the emulator node to have a consistent clock. This is currently not an issue since it is only possible to run the emulator as a single process, and I can't imagine that will change given our intended usage of the emulator as a PoC tool.

I've tested this locally quite extensively and it seems to work well. It would be possible to add unit tests for `handleFetch` etc. but as we are using this as a PoC tool right now it doesn't seem worth the effort at the moment.