### PR TITLE
Add option to enable only minimum API for standalone consumer

### DIFF
--- a/_examples/kafkaIO/avro/go-server/main.go
+++ b/_examples/kafkaIO/avro/go-server/main.go
@@ -39,8 +39,9 @@ func main() {
 	handler, err := dekaf.NewHandler(dekaf.Config{
 		Host:             *host,
 		Port:             int32(*port),
-		Debug:            true,
+		Debug:            false,
 		RecordsAvailable: records(time.Now()),
+		LimitedAPI:       true,
 	})
 	if err != nil {
 		panic(err)

--- a/_examples/kafkaIO/avro/java/src/main/java/org/estuary/FromDekaf.java
+++ b/_examples/kafkaIO/avro/java/src/main/java/org/estuary/FromDekaf.java
@@ -70,11 +70,8 @@ public class FromDekaf {
                         options.getInputTopic() + "-value"))
 
                 .withLogAppendTime()
-                .commitOffsetsInFinalize()
                 .withConsumerConfigUpdates(
-                    Map.of(
-                        ConsumerConfig.GROUP_ID_CONFIG, "some-group",
-                        ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"))
+                    Map.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"))
                 .withoutMetadata())
         // Extract values as GenericRecords.
         .apply(MapElements.via(

--- a/_examples/kafkaIO/avro/java/src/main/java/org/estuary/FromDekaf.java
+++ b/_examples/kafkaIO/avro/java/src/main/java/org/estuary/FromDekaf.java
@@ -70,8 +70,7 @@ public class FromDekaf {
                         options.getInputTopic() + "-value"))
 
                 .withLogAppendTime()
-                .withConsumerConfigUpdates(
-                    Map.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"))
+                .withConsumerConfigUpdates(Map.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"))
                 .withoutMetadata())
         // Extract values as GenericRecords.
         .apply(MapElements.via(

--- a/_examples/kafkaIO/json/go-server/main.go
+++ b/_examples/kafkaIO/json/go-server/main.go
@@ -35,8 +35,9 @@ func main() {
 	handler, err := dekaf.NewHandler(dekaf.Config{
 		Host:             *host,
 		Port:             int32(*port),
-		Debug:            false,
+		Debug:            true,
 		RecordsAvailable: records(time.Now()),
+		LimitedAPI:       true,
 	})
 	if err != nil {
 		panic(err)

--- a/_examples/kafkaIO/json/go-server/main.go
+++ b/_examples/kafkaIO/json/go-server/main.go
@@ -35,7 +35,7 @@ func main() {
 	handler, err := dekaf.NewHandler(dekaf.Config{
 		Host:             *host,
 		Port:             int32(*port),
-		Debug:            true,
+		Debug:            false,
 		RecordsAvailable: records(time.Now()),
 		LimitedAPI:       true,
 	})

--- a/_examples/kafkaIO/json/java/src/main/java/org/estuary/FromDekaf.java
+++ b/_examples/kafkaIO/json/java/src/main/java/org/estuary/FromDekaf.java
@@ -58,10 +58,8 @@ public class FromDekaf {
                 .withValueDeserializer(StringDeserializer.class)
 
                 .withLogAppendTime()
-                .commitOffsetsInFinalize()
                 .withConsumerConfigUpdates(
                     Map.of(
-                        ConsumerConfig.GROUP_ID_CONFIG, "some-group",
                         ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"))
                 .withoutMetadata())
         // Extract values as JSON.

--- a/protocol/api_versions.go
+++ b/protocol/api_versions.go
@@ -23,3 +23,11 @@ var APIVersions = []APIVersion{
 	{APIKey: CreateTopicsKey, MinVersion: 0, MaxVersion: 1},
 	{APIKey: DeleteTopicsKey, MinVersion: 0, MaxVersion: 0},
 }
+
+var APIVersionsLimited = []APIVersion{
+	{APIKey: ProduceKey, MinVersion: 0, MaxVersion: 2}, // Python beam connector requires this, although it does not use it.
+	{APIKey: FetchKey, MinVersion: 0, MaxVersion: 3},
+	{APIKey: OffsetsKey, MinVersion: 0, MaxVersion: 1},
+	{APIKey: MetadataKey, MinVersion: 0, MaxVersion: 2},
+	{APIKey: APIVersionsKey, MinVersion: 0, MaxVersion: 0},
+}


### PR DESCRIPTION
This adds a configuration option to enable only a very minimal set of APIs needed to support a "standalone consumer", which would not support anything to do with a [group coordinator](https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-OffsetCommit/FetchAPI). Broadly, this disallows offset committing or fetching for a particular topic, and joining/leaving/syncing with a group.

The associated example pipelines are also updated here to show the kind of configuration required to work with this minimal API. What is needed is to disallow committing offsets.